### PR TITLE
Add tests for data and receipt modules

### DIFF
--- a/src/budget_bot/__init__.py
+++ b/src/budget_bot/__init__.py
@@ -1,0 +1,22 @@
+"""Expose convenience attributes lazily to avoid heavy imports."""
+
+__all__ = [
+    "load_data",
+    "save_data",
+    "DEFAULT_DATA",
+    "parse_expense_message",
+    "parse_receipt_image",
+]
+
+
+def __getattr__(name):
+    if name in {"load_data", "save_data", "DEFAULT_DATA"}:
+        from . import data
+        return getattr(data, name)
+    if name == "parse_expense_message":
+        from . import utils
+        return utils.parse_expense_message
+    if name == "parse_receipt_image":
+        from . import receipt
+        return receipt.parse_receipt_image
+    raise AttributeError(name)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+import budget_bot.data as data
+
+
+def test_load_defaults_and_save_creates_file(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(data, "DATA_PATH", data_dir)
+    monkeypatch.setattr(data, "DATA_FILE", data_dir / "budget.json")
+
+    # File should not exist initially
+    assert not data.DATA_FILE.exists()
+
+    loaded = data.load_data()
+    assert loaded == data.DEFAULT_DATA
+    assert not data.DATA_FILE.exists()
+
+    loaded["incomes"].append({"amount": 10})
+    data.save_data(loaded)
+
+    assert data.DATA_FILE.exists()
+    with data.DATA_FILE.open("r", encoding="utf-8") as f:
+        saved = json.load(f)
+    assert saved == loaded

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,0 +1,32 @@
+import sys
+import types
+from pathlib import Path
+
+# Provide stub modules so receipt can be imported without real dependencies
+fake_pytesseract = types.ModuleType("pytesseract")
+fake_pytesseract.image_to_string = lambda img, lang=None: ""
+sys.modules.setdefault("pytesseract", fake_pytesseract)
+
+fake_pil = types.ModuleType("PIL")
+class FakeImage:
+    @staticmethod
+    def open(path):
+        return path
+fake_pil.Image = FakeImage
+sys.modules.setdefault("PIL", fake_pil)
+
+import budget_bot.receipt as receipt
+
+
+def test_parse_receipt_image(monkeypatch, tmp_path):
+    sample_text = "20 продукты\n15,5 подарок\nнеподходящая строка"
+    monkeypatch.setattr(
+        receipt.pytesseract,
+        "image_to_string",
+        lambda *args, **kwargs: sample_text,
+    )
+    monkeypatch.setattr(receipt, "Image", FakeImage)
+
+    path = tmp_path / "dummy.png"
+    result = receipt.parse_receipt_image(path)
+    assert result == [(20.0, "продукты"), (15.5, "подарок")]


### PR DESCRIPTION
## Summary
- expose lazy package attributes in `__init__`
- add tests for loading and saving JSON data
- add tests for parsing receipt images without real PIL/pytesseract

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876473750308322b9e9606fc867b0ca