### PR TITLE
Use .env for configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in your tokens
+TELEGRAM_TOKEN=
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
    ```bash
    sudo apt install tesseract-ocr tesseract-ocr-rus
    ```
-3. Создайте переменные окружения `TELEGRAM_TOKEN` и `OPENAI_API_KEY`.
+3. Скопируйте файл `.env.example` в `.env` и заполните в нём `TELEGRAM_TOKEN` и
+   `OPENAI_API_KEY`.
 4. Запустите бота:
 
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-telegram-bot>=20.0
 openai>=1.0
 pytesseract
 pillow
+python-dotenv

--- a/src/budget_bot/bot.py
+++ b/src/budget_bot/bot.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
 from typing import Tuple
 
@@ -12,11 +11,12 @@ from .data import load_data, save_data
 from .categorizer import categorize_description
 from .receipt import parse_receipt_image
 from .utils import parse_expense_message
+from .config import TELEGRAM_TOKEN
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-TOKEN = os.getenv("TELEGRAM_TOKEN")
+TOKEN = TELEGRAM_TOKEN
 
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/src/budget_bot/config.py
+++ b/src/budget_bot/config.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+import openai
+
+# Load environment variables from .env located at project root
+load_dotenv(Path(__file__).resolve().parents[2] / ".env")
+
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+if OPENAI_API_KEY:
+    openai.api_key = OPENAI_API_KEY


### PR DESCRIPTION
## Summary
- add python-dotenv dependency and config loader
- provide `.env.example` with required variables
- update README to describe .env usage
- load TELEGRAM_TOKEN via new config module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68764ecd0e188322aed038e7848b7964