### PR TITLE
Fix categorize_description for OpenAI v1

### DIFF
--- a/src/budget_bot/categorizer.py
+++ b/src/budget_bot/categorizer.py
@@ -1,6 +1,7 @@
 """Categorization utilities using OpenAI's API."""
 from typing import Optional
 
+import logging
 import openai
 
 # You need to set OPENAI_API_KEY environment variable
@@ -14,10 +15,14 @@ prompt_template = (
 )
 
 
+client = openai.OpenAI()
+
+
 def categorize_description(description: str) -> Optional[str]:
     """Return a category for the description."""
+    logging.info("Description to categorize: %s", description)
     try:
-        response = openai.ChatCompletion.create(
+        response = client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[
                 {"role": "system", "content": prompt_template},
@@ -25,6 +30,8 @@ def categorize_description(description: str) -> Optional[str]:
             ],
             max_tokens=10,
         )
-        return response.choices[0].message["content"].strip().lower()
+        logging.info("Response from OpenAI: %s", response)
+        return response.choices[0].message.content.strip().lower()
     except Exception:
+        logging.error("Error categorizing description", exc_info=True)
         return None

--- a/tests/test_categorizer.py
+++ b/tests/test_categorizer.py
@@ -1,0 +1,40 @@
+import sys
+import types
+
+# Provide a fake openai module before importing the module under test
+fake_openai = types.ModuleType("openai")
+fake_openai.OpenAI = lambda *args, **kwargs: None
+sys.modules.setdefault("openai", fake_openai)
+
+import budget_bot.categorizer as categorizer
+
+class FakeResponse:
+    def __init__(self, content):
+        msg = types.SimpleNamespace(content=content)
+        self.choices = [types.SimpleNamespace(message=msg)]
+
+def test_categorize_description(monkeypatch):
+    class FakeClient:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=self.create)
+            )
+
+        def create(self, *args, **kwargs):
+            return FakeResponse("groceries")
+
+    monkeypatch.setattr(categorizer, "client", FakeClient())
+    assert categorizer.categorize_description("20 продукты") == "groceries"
+
+def test_categorize_description_error(monkeypatch):
+    class ErrorClient:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=self.create)
+            )
+
+        def create(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(categorizer, "client", ErrorClient())
+    assert categorizer.categorize_description("20 продукты") is None


### PR DESCRIPTION
## Summary
- update `categorize_description` to use the OpenAI v1 client
- add unit tests for categorization logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876531c86c083228d9f17eded55857a