### PR TITLE
Handle missing dependencies and API key

### DIFF
--- a/src/budget_bot/categorizer.py
+++ b/src/budget_bot/categorizer.py
@@ -1,6 +1,8 @@
 """Categorization utilities using OpenAI's API."""
 from typing import Optional
 
+from .config import OPENAI_API_KEY
+
 import logging
 import openai
 
@@ -15,7 +17,10 @@ prompt_template = (
 )
 
 
-client = openai.OpenAI()
+if OPENAI_API_KEY:
+    client = openai.OpenAI(api_key=OPENAI_API_KEY)
+else:
+    client = openai.OpenAI()
 
 
 def categorize_description(description: str) -> Optional[str]:

--- a/src/budget_bot/config.py
+++ b/src/budget_bot/config.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    def load_dotenv(*args, **kwargs):
+        """Fallback when python-dotenv isn't installed."""
+        return False
 import openai
 
 # Load environment variables from .env located at project root


### PR DESCRIPTION
## Summary
- allow running without python-dotenv installed
- initialize OpenAI client using optional API key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687656416d048322992e65e502f8bfe4